### PR TITLE
원상복귀 "JDBCTemplate Connection 싱글턴 패턴으로 변경"

### DIFF
--- a/CrowdFundingPro/src/com/kh/common/JDBCTemplate.java
+++ b/CrowdFundingPro/src/com/kh/common/JDBCTemplate.java
@@ -8,43 +8,39 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
-
+//*****************수정하지마세요*********************
 public class JDBCTemplate {
-
-	private static Connection conn = null;
-
 	public static Connection getConnection() {
 
-		if (conn == null) {
+		Connection conn = null;
 
-			Properties prop = new Properties();
+		Properties prop = new Properties();
 
-			String fileName = JDBCTemplate.class.getResource("/sql/driver/driver.properties").getPath();
+		String fileName = JDBCTemplate.class.getResource("/sql/driver/driver.properties").getPath();
 
-			try {
-				prop.load(new FileReader(fileName));
+		try {
+			prop.load(new FileReader(fileName));
 
-				String driver = prop.getProperty("driver");
-				String url = prop.getProperty("url");
-				String user = prop.getProperty("username");
-				String password = prop.getProperty("password");
+			String driver = prop.getProperty("driver");
+			String url = prop.getProperty("url");
+			String user = prop.getProperty("username");
+			String password = prop.getProperty("password");
 
-				// 1. 클래스 객체 등록, Driver 등록
-				Class.forName(driver);
+			// 1. 클래스 객체 등록, Driver 등록
+			Class.forName(driver);
 
-				// 2. DBMS와 연결
-				conn = DriverManager.getConnection(url, user, password);
+			// 2. DBMS와 연결
+			conn = DriverManager.getConnection(url, user, password);
 
-				conn.setAutoCommit(false);
+			conn.setAutoCommit(false);
 
-			} catch (IOException e) {
-				e.printStackTrace();
-			} catch (SQLException e) {
-				e.printStackTrace();
-			} catch (ClassNotFoundException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}
+		} catch (IOException e) {
+			e.printStackTrace();
+		} catch (SQLException e) {
+			e.printStackTrace();
+		} catch (ClassNotFoundException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
 		}
 
 		return conn;


### PR DESCRIPTION
싱글턴 패턴 오류 발생 이슈로 인한 원상 복귀

오류 증상 : db 요청 이후 종료됨
원인 확인 : 매 서비스 이후 close를 해주었기 때문 (JDBC 수업 내용에는 마지막에 close 한번함)
해결 방안
매 서비스에 있는 close 제거 후 마지막에 한번 close 하는 것으로 수정해야함
-> 방법 찾아본 후 해결방법 나오면 수정 예정